### PR TITLE
Fixed a bug in SSL_read in Win32

### DIFF
--- a/pockethttp/win32/httpBase.h
+++ b/pockethttp/win32/httpBase.h
@@ -314,6 +314,14 @@ public:
 			{
 				MoveMemory(m_sendBuff, pExtraBuffer->pvBuffer, pExtraBuffer->cbBuffer);
 				m_cbRead = pExtraBuffer->cbBuffer;
+				
+				/* Citing MSDN:
+				 * Sometimes an application will read data from the remote party, attempt 
+				 * to decrypt it by using DecryptMessage (Schannel), and discover that 
+				 * DecryptMessage (Schannel) succeeded but the output buffers are empty. 
+				 * This is normal behavior, and applications must be able to deal with it.
+				 */
+				if (pDataBuffer && pDataBuffer->cbBuffer == 0) continue;
 			}
 			else
 			{


### PR DESCRIPTION
Fixed a bug in SSL_read that causes the library to not work with HTTPS-connections, especially on Windows 7 and higher.